### PR TITLE
Change UI port to 8080

### DIFF
--- a/roles/virtcontroller/templates/virt_ui.yml.j2
+++ b/roles/virtcontroller/templates/virt_ui.yml.j2
@@ -9,9 +9,9 @@ metadata:
     service: migration-ui
 spec:
   ports:
-    - name: port-9000
-      port: 9000
-      targetPort: 9000
+    - name: port-8080
+      port: 8080
+      targetPort: 8080
       protocol: TCP
   selector:
     app: migration
@@ -44,7 +44,7 @@ spec:
             - name: META_FILE
               value: {{ ui_configmap_path }}/virtmeta.json
           ports:
-            - containerPort: 9000
+            - containerPort: 8080
               protocol: TCP
           volumeMounts:
             - name: "{{ ui_configmap_name }}"


### PR DESCRIPTION
The nginx server in the UI pod is actually listening on port 8080, so the UI is inaccessible when using 9000 in pod and service spec. This pull request changes the ports to 8080.