### PR TITLE
virt-controller: RBAC allow get/list namespaces

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-virt-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-virt-operator.v99.0.0.clusterserviceversion.yaml
@@ -277,6 +277,14 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
   installModes:
   - type: OwnNamespace
     supported: true


### PR DESCRIPTION
- Fix #18

See sample clusterrole bound to virt-controller sa below : 
```
oc describe clusterrole konveyor-virt-operator.v99.0.0-964458977
Name:         konveyor-virt-operator.v99.0.0-964458977
Labels:       olm.owner=konveyor-virt-operator.v99.0.0
              olm.owner.kind=ClusterServiceVersion
              olm.owner.namespace=openshift-migration
              operators.coreos.com/virt-operator.openshift-migration=
Annotations:  <none>
PolicyRule:
  Resources                                       Non-Resource URLs  Resource Names  Verbs
  ---------                                       -----------------  --------------  -----
  *.virt.konveyor.io                              []                 []              [*]
  secrets                                         []                 []              [get list watch create update patch delete]
  namespaces                                      []                 []              [get list watch]
  network-attachment-definitions.k8s.cni.cncf.io  []                 []              [get list watch]
  storageclasses.storage.k8s.io                   []                 []              [get list watch]
```