### PR TITLE
Add services CA certs to virt-ui deployment environment

### DIFF
--- a/roles/virtcontroller/templates/virt_ui.yml.j2
+++ b/roles/virtcontroller/templates/virt_ui.yml.j2
@@ -43,6 +43,8 @@ spec:
           env:
             - name: META_FILE
               value: {{ ui_configmap_path }}/virtMeta.json
+            - name: NODE_EXTRA_CA_CERTS
+              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
When the user connects to the UI, the following error is thrown:

```
{
  "message": "request+to+https://api.cluster-test.example.com:6443/.well-known/oauth-authorization-server+failed,+reason:+self+signed+certificate+in+certificate+chain",
  "type": "system",
  "errno": "SELF_SIGNED_CERT_IN_CHAIN",
  "code": "SELF_SIGNED_CERT_IN_CHAIN"
}
```

Obviously, this is due to the fact that the OpenShift cluster is deployed with self-signed certificates, and NodeJS refuses to use insecure connection. However, to allow consuming the API from applications, the cluster mounts the self-signed CA chain in all the pods in the hard coded path `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`.

This pull request adds the [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file) environment variable to the `virt-ui` deployment, so that it propagates to the pod.