### PR TITLE
Extend virt-controller cluster role

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-virt-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-virt-operator.v99.0.0.clusterserviceversion.yaml
@@ -253,6 +253,7 @@ spec:
           - ""
           resources:
           - secrets
+          - namespaces
           verbs:
           - get
           - list
@@ -278,9 +279,22 @@ spec:
           - list
           - watch
         - apiGroups:
-          - ""
+          - v2v.kubevirt.io
           resources:
-          - namespaces
+          - resourcemappings
+          - virtualmachineimports
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
           verbs:
           - get
           - list

--- a/roles/virtcontroller/templates/virt_controller_rbac.yml.j2
+++ b/roles/virtcontroller/templates/virt_controller_rbac.yml.j2
@@ -15,6 +15,7 @@ rules:
   - ""
   resources:
   - secrets
+  - namespaces
   verbs:
   - get
   - list
@@ -35,6 +36,27 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - v2v.kubevirt.io
+  resources:
+  - resourcemappings
+  - virtualmachineimports
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - datavolumes
   verbs:
   - get
   - list


### PR DESCRIPTION
To be able to run a migration, the `virt-controller` role needs to be extended with the following permissions:
- `namespaces` - `any` - It allows `virt-controller` to create the target namespace if it doesn't exist.
- `resourcemappings`, `virtualmachineimports` - `any` - It allows `virt-controller` to manage the VMIO resources.
- `datavolumes` - `read` - It allows `virt-controller` to monitor the disks transfer directly from the Data Volumes.

Fixes #23 