### PR TITLE
catalogsource: Implement updateStrategy

### DIFF
--- a/virt-operator-bundle.yaml
+++ b/virt-operator-bundle.yaml
@@ -4,5 +4,10 @@ metadata:
   name: konveyor-for-vms
   namespace: openshift-marketplace
 spec:
+  displayName: Konveyor for VMs Operator
+  publisher: Red Hat
   sourceType: grpc
   image: quay.io/konveyor/virt-operator-index:latest
+  updateStrategy:
+    registryPoll:
+      interval: 10m


### PR DESCRIPTION
Enhancement : 

* Allows an updateStrategy set to poll every 10 minutes for catalogsource updates, requires marketplace operator monitoring for updates.

See references here : 

https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/catalog-polling.md
https://docs.openshift.com/container-platform/4.5/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.html