### PR TITLE
Enable TLS for inventory

### DIFF
--- a/roles/virtcontroller/templates/inventory.yml.j2
+++ b/roles/virtcontroller/templates/inventory.yml.j2
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name=inventory-tls
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
@@ -9,9 +11,9 @@ metadata:
   namespace: {{ virt_namespace }}
 spec:
   ports:
-  - port: 80
+  - port: 8443
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8443
   selector:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
@@ -29,5 +31,5 @@ spec:
     kind: Service
     name: inventory
   tls:
-    termination: edge
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect

--- a/roles/virtcontroller/templates/inventory.yml.j2
+++ b/roles/virtcontroller/templates/inventory.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name=inventory-tls
+    service.beta.openshift.io/serving-cert-secret-name: inventory-tls
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"

--- a/roles/virtcontroller/templates/virt_controller.yml.j2
+++ b/roles/virtcontroller/templates/virt_controller.yml.j2
@@ -113,7 +113,7 @@ spec:
         imagePullPolicy: {{ image_pull_policy }}
         ports:
         - name: api
-          containerPort: 8080
+          containerPort: 8443
           name: webhook-server
           protocol: TCP
         resources:
@@ -126,11 +126,16 @@ spec:
         volumeMounts:
         - mountPath: {{ inventory_volume_path }}
           name: inventory
+        - mountPath: /var/run/secrets/inventory-tls
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert
         secret:
           defaultMode: 420
           secretName: webhook-server-secret
+      - name: inventory-tls
+        secret:
+          defaultMode: 420
+          secretName: inventory-tls
       - name: inventory
         emptyDir: {}

--- a/roles/virtcontroller/templates/virt_controller.yml.j2
+++ b/roles/virtcontroller/templates/virt_controller.yml.j2
@@ -106,6 +106,8 @@ spec:
           value: inventory
         - name: SECRET_NAME
           value: webhook-server-secret
+        - name: API_PORT
+          value: "8443"
         - name: API_TLS_CERTIFICATE
           value: /var/run/secrets/inventory-tls/tls.crt
         - name: API_TLS_KEY
@@ -131,6 +133,7 @@ spec:
         - mountPath: {{ inventory_volume_path }}
           name: inventory
         - mountPath: /var/run/secrets/inventory-tls
+          name: inventory-tls
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert

--- a/roles/virtcontroller/templates/virt_controller.yml.j2
+++ b/roles/virtcontroller/templates/virt_controller.yml.j2
@@ -106,6 +106,10 @@ spec:
           value: inventory
         - name: SECRET_NAME
           value: webhook-server-secret
+        - name: API_TLS_CERTIFICATE
+          value: /var/run/secrets/inventory-tls/tls.crt
+        - name: API_TLS_KEY
+          value: /var/run/secrets/inventory-tls/tls.key
         envFrom:
         - configMapRef:
             name: virt-controller


### PR DESCRIPTION
This pull request is a companion for [konveyor/controller#29](https://github.com/konveyor/controller/pull/29), [konveyor/virt-controller#79](https://github.com/konveyor/virt-controller/pull/79). The goal is to enable TLS for the inventory container, also for internal traffic.

- An annotation is added to the service to get a secret name `inventory-tls` with a certificate/key pair generated by openshift-service-serving-signer.
- The secret is mounted in `/var/run/secrets/inventory-tls`.
- The service and container ports are changed to 8443.
- The route is changed to reencrypt traffic from external clients ; internal clients also have the CA chain as `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`.

More information on using service serving certificates is available at [OpenShift > Security and compliance > Configuring certificates > Securing service traffic using service serving certificate secrets](https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html).