### PR TITLE
Enable TLS for UI

### DIFF
--- a/roles/virtcontroller/templates/virt_ui.yml.j2
+++ b/roles/virtcontroller/templates/virt_ui.yml.j2
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name=migration-ui-tls
   name: migration-ui
   namespace: "{{ virt_namespace }}"
   labels:
@@ -9,9 +11,9 @@ metadata:
     service: migration-ui
 spec:
   ports:
-    - name: port-8080
-      port: 8080
-      targetPort: 8080
+    - name: port-8443
+      port: 8443
+      targetPort: 8443
       protocol: TCP
   selector:
     app: migration
@@ -46,12 +48,18 @@ spec:
             - name: NODE_EXTRA_CA_CERTS
               value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               protocol: TCP
           volumeMounts:
             - name: "{{ ui_configmap_name }}"
               mountPath: "{{ ui_configmap_path }}"
+            - name: migration-ui-tls
+              mountPath: /var/run/secrets/migration-ui-tls
       volumes:
         - name: "{{ ui_configmap_name }}"
           configMap:
             name: "{{ ui_configmap_name }}"
+        - name: migration-ui-tls
+          secret:
+            defaultMode: 420
+            secretName: migration-ui-tls

--- a/roles/virtcontroller/templates/virt_ui_route.yml.j2
+++ b/roles/virtcontroller/templates/virt_ui_route.yml.j2
@@ -13,8 +13,6 @@ spec:
   to:
     kind: Service
     name: migration-ui
-  port:
-    targetPort: port-8080
   tls:
-    termination: edge
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
This pull request is a companion for [konveyor/virt-ui#172](https://github.com/konveyor/virt-ui/pull/172). The goal is to enable TLS for the UI container, also for internal traffic.

- An annotation is added to the service to get a secret named `migration-ui-tls` with a certificate/key pair generated by openshift-service-serving-signer.
- The secret is mounted in `/var/run/secrets/migration-ui-tls`.
- The service and container ports are changed to 8443.
- The route is changed to reencrypt traffic from external clients ; internal clients also have the CA chain as `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`.

More information on using service serving certificates is available at [OpenShift > Security and compliance > Configuring certificates > Securing service traffic using service serving certificate secrets](https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html).