### PR TITLE
OLM: Implement minKubeVersion

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-virt-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-virt-operator.v99.0.0.clusterserviceversion.yaml
@@ -6,7 +6,8 @@ metadata:
   annotations:
     olm.skipRange: '>=0.0.0 <99.0.0'
     capabilities: Seamless Upgrades
-    description: Facilitates migration of VM workloads to OpenShift Virtualization
+    description: >-
+      Facilitates migration of VM workloads to OpenShift Virtualization
     categories: 'OpenShift Optional'
     containerImage: quay.io/konveyor/virt-operator:latest
     createdAt: 2020-06-16T11:21:00Z
@@ -76,10 +77,8 @@ spec:
   - name: payload
     image: quay.io/konveyor/virt-payload:latest
   displayName: Konveyor Operator for VMs
-  description: |
-    The Konveyor Virt Operator enables installation of the OpenShift VMs migration tooling.
-
-    Prior to installing create the openshift-migration namespace (oc create namespace openshift-migration) and install the operator within this namespace.
+  description: |+
+    The Konveyor Virt Operator fully manages the deployment and life cycle of Migration Toolkit for VMs on OpenShift.
 
     If you experience any issues or have feature requests, please [file an issue in our Github repository](https://github.com/konveyor/virt-operator/issues)
   keywords: ['migration']
@@ -326,6 +325,7 @@ spec:
   - name: Konveyor Virt Operator
     url: https://github.com/konveyor/virt-operator
   version: 99.0.0
+  minKubeVersion: 1.19.0
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
* Require a minimum 1.9.0 (OCP 4.6) release for MTV deployments, aligns with the minimum pre-reqs for MTV. (CNV)
* Clusters older than 4.6 will show a pending installation with a requirements not met message
* Minor tweaks to description