### PR TITLE
Update virt-controller containers command

### DIFF
--- a/roles/virtcontroller/templates/virt_controller.yml.j2
+++ b/roles/virtcontroller/templates/virt_controller.yml.j2
@@ -62,7 +62,7 @@ spec:
       containers:
       - name: main
         command:
-        - /manager
+        - /usr/local/bin/manager
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -96,7 +96,7 @@ spec:
           readOnly: true
       - name: inventory
         command:
-        - /manager
+        - /usr/local/bin/manager
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
This is a follow-up for https://github.com/konveyor/virt-controller/pull/41, because the path of the `manager` command is now `/usr/local/bin/manager`.