### PR TITLE
Use internal service URLs

### DIFF
--- a/roles/virtcontroller/vars/main.yml
+++ b/roles/virtcontroller/vars/main.yml
@@ -2,7 +2,7 @@
 virt_ui_configmap_data:
   namespace: "{{ virt_namespace }}"
   configNamespace: "{{ ui_config_namespace }}"
-  clusterApi: "https://api.openshift-apiserver.svc.cluster.local"
+  clusterApi: "https://kubernetes.default.svc.cluster.local"
   inventoryApi: "http://inventory.{{ virt_namespace }}.svc.cluster.local"
   inventoryPayloadApi: "http://inventory-payload.{{ virt_namespace }}.svc.cluster.local:8080"
   oauth:

--- a/roles/virtcontroller/vars/main.yml
+++ b/roles/virtcontroller/vars/main.yml
@@ -1,10 +1,10 @@
 ---
 virt_ui_configmap_data:
-  clusterApi: "{{ ui_cluster_api_endpoint }}"
   namespace: "{{ virt_namespace }}"
   configNamespace: "{{ ui_config_namespace }}"
-  inventoryApi: "{{ inventory_api_url }}"
-  inventoryPayloadApi: "{{ inventory_payload_url }}"
+  clusterApi: "https://api.openshift-apiserver.svc.cluster.local"
+  inventoryApi: "http://inventory.{{ virt_namespace }}.svc.cluster.local"
+  inventoryPayloadApi: "http://inventory-payload.{{ virt_namespace }}.svc.cluster.local:8080"
   oauth:
     clientId: migration
     redirectUrl: "{{ ui_oauth_redirect_url }}"


### PR DESCRIPTION
With [konveyor/virt-ui#214](https://github.com/konveyor/virt-ui/pull/214), the UI uses internal service URLs to reach OpenShift API, inventory and inventory payload services. Rather than using hard coded values, the UI should use variables exposes in virtMeta.json file. This pull request updates the values in this file to point to internal services.