### PR TITLE
Enable TLS for inventory-payload

### DIFF
--- a/roles/virtcontroller/templates/inventory_payload.yml.j2
+++ b/roles/virtcontroller/templates/inventory_payload.yml.j2
@@ -22,9 +22,22 @@ spec:
         - name: inventory-payload
           image: "{{ inventory_payload_image_fqin }}"
           imagePullPolicy: "{{ image_pull_policy }}"
+          env:
+            - name: API_TLS_CERTIFICATE
+              value: /var/run/secrets/inventory-payload-tls/tls.crt
+            - name: API_TLS_KEY
+              value: /var/run/secrets/inventory-payload-tls/tls.key
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               protocol: TCP
+          volumeMounts:
+            - name: inventory-payload-tls
+              mountPath: /var/run/secrets/inventory-payload-tls
+      volumes:
+        - name: inventory-payload-tls
+          secret:
+            secretName: inventory-payload-tls
+            defaultMode: 420
 ---
 apiVersion: v1
 kind: Service
@@ -34,11 +47,13 @@ metadata:
   labels:
     app: migration
     service: inventory-payload
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: inventory-payload-tls
 spec:
   ports:
-    - name: port-8080
-      port: 8080
-      targetPort: 8080
+    - name: port-8443
+      port: 8443
+      targetPort: 8443
       protocol: TCP
   selector:
     app: migration
@@ -59,7 +74,7 @@ spec:
     kind: Service
     name: inventory-payload
   port:
-    targetPort: port-8080
+    targetPort: port-8443
   tls:
-    termination: edge
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect

--- a/roles/virtcontroller/vars/main.yml
+++ b/roles/virtcontroller/vars/main.yml
@@ -4,7 +4,7 @@ virt_ui_configmap_data:
   configNamespace: "{{ ui_config_namespace }}"
   clusterApi: "https://kubernetes.default.svc.cluster.local"
   inventoryApi: "https://inventory.{{ virt_namespace }}.svc.cluster.local:8443"
-  inventoryPayloadApi: "http://inventory-payload.{{ virt_namespace }}.svc.cluster.local:8080"
+  inventoryPayloadApi: "https://inventory-payload.{{ virt_namespace }}.svc.cluster.local:8443"
   oauth:
     clientId: migration
     redirectUrl: "{{ ui_oauth_redirect_url }}"


### PR DESCRIPTION
This is a follow-up PR for https://github.com/konveyor/virt-payload/pull/10. It does the following things:

- Annotate the `inventory-payload` service to generate the secret with TLS cert/key.
- Mount the secret in the `inventory-payload` pod.
- Pass the `API_TLS_CERTIFICATE` and `API_TLS_KEY` environment variable to the pod to enable TLS in Sinatra.
- Update pod and service ports to 8443.
- Update the route to reencrypt traffic.
- Update the UI config to use the new inventory payload URL.

Fixes https://github.com/konveyor/virt-payload/issues/12.