### PR TITLE
Pass environment variables to enable TLS in inventory client

### DIFF
--- a/roles/virtcontroller/templates/virt_controller.yml.j2
+++ b/roles/virtcontroller/templates/virt_controller.yml.j2
@@ -72,6 +72,12 @@ spec:
           value: main
         - name: MA_ROUTE
           value: {{ ma_route }}
+        - name: API_HOST
+          value: inventory.{{ virt_namespace }}.svc.cluster.local
+        - name: API_PORT
+          value: "8443"
+        - name: API_TLS_ENABLED
+          value: "true"
         - name: SECRET_NAME
           value: webhook-server-secret
         envFrom:
@@ -108,6 +114,8 @@ spec:
           value: webhook-server-secret
         - name: API_PORT
           value: "8443"
+        - name: API_TLS_ENABLED
+          value: "true"
         - name: API_TLS_CERTIFICATE
           value: /var/run/secrets/inventory-tls/tls.crt
         - name: API_TLS_KEY


### PR DESCRIPTION
This pull request adds that `API_TLS_ENABLED` environment variable to the `main` and `inventory` containers of the `virt-controller` pod. It also adds the `API_PORT` environment variable to the `main` container. This way, the inventory client (`main`) know how to connect to the inventory server (`inventory`).

And because the certificate used is signed for `inventory.<virt_namespace>.svc` and `inventory.<virt_namespace>.svc.cluster.local`, the `API_HOST` is also added to the `main` container, so that the certificate validation succeeds.